### PR TITLE
Add allocation methods based on Lasso

### DIFF
--- a/examples/controller_lqr_LC62_PI.py
+++ b/examples/controller_lqr_LC62_PI.py
@@ -1,0 +1,228 @@
+"""
+LC62-50B LQR control 
+considering Flight mode transition
+via Control allocation
+
+case 2. Pseudo Inverse controller
+"""
+
+import argparse
+
+import fym
+import matplotlib.pyplot as plt
+import numpy as np
+from fym.utils.rot import angle2quat
+from matplotlib import animation
+
+import ftc
+from ftc.models.LC62R import LC62R
+from ftc.plotframe import LC62Frame, update_plot
+from ftc.utils import safeupdate
+
+np.seterr(all="raise")
+
+
+class MyEnv(fym.BaseEnv):
+    ang = np.random.uniform(-np.deg2rad(0), np.deg2rad(0), size=(3, 1))
+    ENV_CONFIG = {
+        "fkw": {
+            "dt": 0.01,
+            "max_t": 10,
+        },
+        "plant": {
+            "init": {
+                "pos": np.vstack((0, 0, 0)),
+                "vel": np.vstack((0, 0, 0)),
+                "quat": angle2quat(ang[2], ang[1], ang[0]),
+                "omega": np.zeros((3, 1)),
+            },
+        },
+    }
+
+    def __init__(self, env_config={}):
+        env_config = safeupdate(self.ENV_CONFIG, env_config)
+        super().__init__(**env_config["fkw"])
+        self.plant = LC62R(env_config["plant"])
+
+        # VTOL
+        self.x_trims_HV, self.u_trims_fixed_HV = self.plant.get_trim_fixed(
+            fixed={"h": 10, "VT": 0}
+        )
+        self.u_trims_vtol_HV = self.plant.get_trim_vtol(
+            fixed={"x_trims": self.x_trims_HV, "u_trims_fixed": self.u_trims_fixed_HV}
+        )
+
+        self.Q_HV = np.diag([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0])
+        self.R_HV = np.diag([1, 1, 1, 1, 1, 1])
+
+        # FW
+        self.x_trims_FW, self.u_trims_fixed_FW = self.plant.get_trim_fixed(
+            fixed={"h": 10, "VT": 5}
+        )
+        self.u_trims_vtol_FW = self.plant.get_trim_vtol(
+            fixed={"x_trims": self.x_trims_FW, "u_trims_fixed": self.u_trims_fixed_FW}
+        )
+        self.Q_FW = np.diag([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0])
+        self.R_FW = np.diag([1, 1, 1, 1, 1, 1])
+
+        self.controller = ftc.make("LQR-LC62-PI", self)
+
+    def step(self):
+        env_info, done = self.update()
+        return done, env_info
+
+    def observation(self):
+        return self.observe_flat()
+
+    def get_ref(self, t, *args):
+        # VTOL + Hovering
+        posd = np.vstack((0,0,-10))
+        posd_dot = np.vstack((0,0,0))
+        mode = "VTOL"
+
+        refs = {"posd": posd, "posd_dot": posd_dot, "mode": mode}
+        return [refs[key] for key in args]
+
+    def set_dot(self, t):
+        ctrls, controller_info = self.controller.get_control(t, self)
+
+        pos, vel, quat, omega = self.plant.observe_list()
+        FM = self.plant.get_FM(pos, vel, quat, omega, ctrls)
+        self.plant.set_dot(t, FM)
+
+        env_info = {
+            "t": t,
+            **self.observe_dict(),
+            **controller_info,
+            "FM": FM,
+            "ctrls": ctrls,
+            # "Lambda": np.ones((11, 1)),
+        }
+
+        return env_info
+
+def run():
+    env = MyEnv()
+    flogger = fym.Logger("data.h5")
+
+    env.reset()
+    try:
+        while True:
+            env.render()
+
+            done, env_info = env.step()
+            flogger.record(env=env_info)
+
+            if done:
+                break
+
+    finally:
+        flogger.close()
+        plot()
+
+
+def plot():
+    data = fym.load("data.h5")["env"]
+
+    """ Figure 1 - States """
+    fig, axes = plt.subplots(3, 2, squeeze=False, sharex=True)
+
+    """ Column 1 - States: Position """
+    ax = axes[0, 0]
+    x = ax.plot(data["t"], data["plant"]["pos"][:, 0].squeeze(-1), "k-")
+    x_ref = ax.plot(data["t"], data["posd"][:, 0].squeeze(-1), "r--")
+    ax.set_ylabel(r"$x$, m")
+    ax.set_xlabel("Time, sec")
+    ax.set_xlim(data["t"][0], data["t"][-1])
+
+    ax = axes[1, 0]
+    ax.plot(data["t"], data["plant"]["pos"][:, 1].squeeze(-1), "k-")
+    ax.plot(data["t"], data["posd"][:, 1].squeeze(-1), "r--")
+    ax.set_ylabel(r"$y$, m")
+    ax.set_xlabel("Time, sec")
+    
+    ax = axes[2, 0]
+    ax.plot(data["t"], data["plant"]["pos"][:, 2].squeeze(-1), "k-")
+    ax.plot(data["t"], data["posd"][:, 2].squeeze(-1), "r--")
+    ax.set_ylabel(r"$z$, m")
+    ax.set_xlabel("Time, sec")
+
+
+    """ Column 2 - States: Velocity """
+    ax = axes[0, 1]
+    ax.plot(data["t"], data["plant"]["vel"][:, 0].squeeze(-1), "k-")
+    ax.plot(data["t"], data["veld"][:, 0].squeeze(-1), "r--")
+    ax.set_ylabel(r"$v_x$, m/s")
+    ax.set_xlabel("Time, sec")
+
+    ax = axes[1, 1]
+    ax.plot(data["t"], data["plant"]["vel"][:, 1].squeeze(-1), "k-")
+    ax.plot(data["t"], data["veld"][:, 1].squeeze(-1), "r--")
+    ax.set_ylabel(r"$v_y$, m/s")
+    ax.set_xlabel("Time, sec")
+    ax.set_ylim(-5, 5)
+    
+    ax = axes[2, 1]
+    ax.plot(data["t"], data["plant"]["vel"][:, 2].squeeze(-1), "k-")
+    ax.plot(data["t"], data["veld"][:, 2].squeeze(-1), "r--")
+    ax.set_ylabel(r"$v_z$, m/s")
+    ax.set_xlabel("Time, sec")
+    ax.set_ylim(-5, 5)
+
+
+    """ Figure 2 - Rotor thrusts """
+    fig, axs = plt.subplots(3, 2, sharex=True)
+    ylabels = np.array(
+        (["Rotor 1", "Rotor 2"], ["Rotor 3", "Rotor 4"], ["Rotor 5", "Rotor 6"])
+    )
+    for i, _ylabel in np.ndenumerate(ylabels):
+        x, y = i
+        ax = axs[i]
+        ax.plot(data["t"], data["ctrls"].squeeze(-1)[:, 2 * x + y], "k-")
+        ax.set_xlim(data["t"][0], data["t"][-1])
+        if i[0] == 2:
+            ax.set_xlabel("Time, sec")
+
+        plt.setp(ax, ylabel=_ylabel)
+
+    fig.tight_layout()
+    fig.subplots_adjust(wspace=0.5)
+    fig.align_ylabels(axs)
+
+
+    """ Figure 3 - Pusher and Control surfaces """
+    fig, axs = plt.subplots(5, 1, sharex=True)
+    ylabels = np.array(
+        ("Pusher 1", "Pusher 2", r"$\delta_a$", r"$\delta_e$", r"$\delta_r$")
+    )
+    for i, _ylabel in enumerate(ylabels):
+        ax = axs[i]
+        ax.plot(data["t"], data["ctrls"].squeeze(-1)[:, i + 6], "k-")
+        ax.set_xlim(data["t"][0], data["t"][-1])
+        ax.grid()
+        plt.setp(ax, ylabel=_ylabel)
+    
+        if i == 4:
+            ax.set_xlabel("Time, sec")
+
+    fig.tight_layout()
+    fig.align_ylabels(axs)
+
+
+def main(args):
+    if args.only_plot:
+        plot()
+        return
+    else:
+        run()
+        if args.plot:
+            plot()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--plot", action="store_true")
+    parser.add_argument("-P", "--only-plot", action="store_true")
+    args = parser.parse_args()
+    main(args)
+

--- a/examples/controller_lqr_LC62_modeEnv.py
+++ b/examples/controller_lqr_LC62_modeEnv.py
@@ -1,0 +1,319 @@
+"""
+LC62-50B LQR control
+considering Flight Mode Envelope
+w.r.t. current velocity 
+
+VTOL mode: use only rotors
+FW   mode: use all actuators
+"""
+
+import argparse
+
+import fym
+import matplotlib.pyplot as plt
+import numpy as np
+from fym.utils.rot import angle2quat, quat2angle
+from matplotlib import animation
+
+import ftc
+from ftc.models.LC62R import LC62R
+from ftc.plotframe import LC62Frame, update_plot
+from ftc.utils import safeupdate
+
+np.seterr(all="raise")
+
+
+class MyEnv(fym.BaseEnv):
+    ang = np.random.uniform(-np.deg2rad(0), np.deg2rad(0), size=(3, 1))
+    ENV_CONFIG = {
+        "fkw": {
+            "dt": 0.01,
+            "max_t": 20,
+        },
+        "plant": {
+            "init": {
+                "pos": np.vstack((0, 0, -10)),
+                "vel": np.vstack((0, 0, 0)),
+                "quat": angle2quat(ang[2], ang[1], ang[0]),
+                "omega": np.zeros((3, 1)),
+            },
+        },
+    }
+
+    def __init__(self, env_config={}):
+        env_config = safeupdate(self.ENV_CONFIG, env_config)
+        super().__init__(**env_config["fkw"])
+        self.plant = LC62R(env_config["plant"])
+        cruise_speed = 40
+
+        # Hovering
+        self.x_trims_HV, self.u_trims_fixed_HV = self.plant.get_trim_fixed(
+            fixed={"h": 10, "VT": 0}
+        )
+        self.u_trims_vtol_HV = self.plant.get_trim_vtol(
+            fixed={"x_trims": self.x_trims_HV, "u_trims_fixed": self.u_trims_fixed_HV}
+        )
+
+        self.Q_HV = np.diag([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0])
+        self.R_HV = 1000 * np.diag([1, 1, 1, 1, 1, 1])
+
+        # # FW
+        # self.x_trims_FW, self.u_trims_fixed_FW = self.plant.get_trim_fixed(
+        #     fixed={"h": 10, "VT": self.cruise_speed}
+        # )
+        # self.u_trims_vtol_FW = self.plant.get_trim_vtol(
+        #     fixed={"x_trims": self.x_trims_FW, "u_trims_fixed": self.u_trims_fixed_FW}
+        # )
+        # self.Q_FW = np.diag([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0])
+        # self.R_FW = 1000 * np.diag([1, 1, 1, 1, 1])
+
+        # FW Flight envelope
+        self.VT_max = cruise_speed
+        self.VT = 5
+        len = int(self.VT_max / self.VT)
+
+        pos_trim = np.zeros((3, len))
+        vel_trim = np.zeros((3, len))
+        quat_trim = np.zeros((4, len))
+        omega_trim = np.zeros((3, len))
+        ang_trim = np.zeros((3, len))
+        rcmds_trim = np.zeros((6, len))
+        pcmds_trim = np.zeros((2, len))
+        dels_trim = np.zeros((3, len))
+        self.x_trims_FW = np.zeros((12, len))
+        self.u_trims_FW = np.zeros((11, len))
+
+        for i in range(len):
+            x_trims_FW, u_trims_fixed_FW = self.plant.get_trim_fixed(
+                fixed={"h": 10, "VT": self.VT * (i + 1)}
+            )
+
+            (
+                pos_trim[:, i : i + 1],
+                vel_trim[:, i : i + 1],
+                quat_trim[:, i : i + 1],
+                omega_trim[:, i : i + 1],
+            ) = x_trims_FW
+
+            ang_trim[:, i : i + 1] = np.vstack(
+                quat2angle(quat_trim[:, i : i + 1])[::-1]
+            )
+
+            (pcmds_trim[:, i : i + 1], dels_trim[:, i : i + 1]) = u_trims_fixed_FW
+
+            rcmds_trim[:, i : i + 1] = self.plant.get_trim_vtol(
+                fixed={"x_trims": x_trims_FW, "u_trims_fixed": u_trims_fixed_FW}
+            )
+
+            self.x_trims_FW[:, i : i + 1] = np.vstack(
+                (
+                    pos_trim[:, i : i + 1],
+                    vel_trim[:, i : i + 1],
+                    ang_trim[:, i : i + 1],
+                    omega_trim[:, i : i + 1],
+                )
+            )
+            self.u_trims_FW[:, i : i + 1] = np.vstack(
+                (
+                    rcmds_trim[:, i : i + 1],
+                    pcmds_trim[:, i : i + 1],
+                    dels_trim[:, i : i + 1],
+                )
+            )
+
+        self.Q_FW = np.zeros((12, 12, len))
+        self.R_FW = np.zeros((5, 5, len))
+        for i in range(len):
+            self.Q_FW[:, :, i] = np.diag([1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0])
+            self.R_FW[:, :, i] = 1000 * np.diag([1, 1, 1, 1, 1])
+
+        self.controller = ftc.make("LQR-LC62-modeEnv", self)
+
+    def step(self):
+        env_info, done = self.update()
+        return done, env_info
+
+    def observation(self):
+        return self.observe_flat()
+
+    def get_ref(self, t, *args):
+        # if 0 <= t <= 20:
+        #     # VTOL + Hovering
+        #     posd = np.vstack((0, 0, -10))
+        #     posd_dot = np.vstack((0, 0, 0))
+        #     mode = "VTOL"
+        # elif 20 < t <= 40:
+        #     # Level Flight
+        #     VT = self.cruise_speed
+        #     posd_dot = np.vstack((VT, 0, 0))
+        #     posd = np.vstack((0, 0, -10)) + (t - 20) * posd_dot
+        #     mode = "FW"
+
+        # Level Flight
+        VT = self.VT_max
+        posd_dot = np.vstack((VT, 0, 0))
+        posd = np.vstack((0, 0, -10)) + t * posd_dot
+        mode = "FW"
+
+        refs = {"posd": posd, "posd_dot": posd_dot, "mode": mode}
+        return [refs[key] for key in args]
+
+    def set_dot(self, t):
+        ctrls, controller_info = self.controller.get_control(t, self)
+
+        pos, vel, quat, omega = self.plant.observe_list()
+        FM = self.plant.get_FM(pos, vel, quat, omega, ctrls)
+        self.plant.set_dot(t, FM)
+
+        env_info = {
+            "t": t,
+            **self.observe_dict(),
+            **controller_info,
+            "FM": FM,
+            "ctrls": ctrls,
+            # "Lambda": np.ones((11, 1)),
+        }
+
+        return env_info
+
+
+def run():
+    env = MyEnv()
+    flogger = fym.Logger("data.h5")
+
+    env.reset()
+    try:
+        while True:
+            env.render()
+
+            done, env_info = env.step()
+            flogger.record(env=env_info)
+
+            if done:
+                break
+
+    finally:
+        flogger.close()
+        plot()
+
+
+def plot():
+    data = fym.load("data.h5")["env"]
+
+    """ Figure 1 - States """
+    fig, axes = plt.subplots(3, 2, squeeze=False, sharex=True)
+
+    """ Column 1 - States: Position """
+    ax = axes[0, 0]
+    x = ax.plot(data["t"], data["plant"]["pos"][:, 0].squeeze(-1), "k-")
+    x_ref = ax.plot(data["t"], data["posd"][:, 0].squeeze(-1), "r--")
+    ax.set_ylabel(r"$x$, m")
+    ax.set_xlabel("Time, sec")
+    ax.set_xlim(data["t"][0], data["t"][-1])
+
+    ax = axes[1, 0]
+    ax.plot(data["t"], data["plant"]["pos"][:, 1].squeeze(-1), "k-")
+    ax.plot(data["t"], data["posd"][:, 1].squeeze(-1), "r--")
+    ax.set_ylabel(r"$y$, m")
+    ax.set_xlabel("Time, sec")
+
+    ax = axes[2, 0]
+    ax.plot(data["t"], data["plant"]["pos"][:, 2].squeeze(-1), "k-")
+    ax.plot(data["t"], data["posd"][:, 2].squeeze(-1), "r--")
+    ax.set_ylabel(r"$z$, m")
+    ax.set_xlabel("Time, sec")
+
+    """ Column 2 - States: Velocity """
+    ax = axes[0, 1]
+    ax.plot(data["t"], data["plant"]["vel"][:, 0].squeeze(-1), "k-")
+    ax.plot(data["t"], data["veld"][:, 0].squeeze(-1), "r--")
+    ax.set_ylabel(r"$v_x$, m/s")
+    ax.set_xlabel("Time, sec")
+
+    ax = axes[1, 1]
+    ax.plot(data["t"], data["plant"]["vel"][:, 1].squeeze(-1), "k-")
+    ax.plot(data["t"], data["veld"][:, 1].squeeze(-1), "r--")
+    ax.set_ylabel(r"$v_y$, m/s")
+    ax.set_xlabel("Time, sec")
+    ax.set_ylim(-5, 5)
+
+    ax = axes[2, 1]
+    ax.plot(data["t"], data["plant"]["vel"][:, 2].squeeze(-1), "k-")
+    ax.plot(data["t"], data["veld"][:, 2].squeeze(-1), "r--")
+    ax.set_ylabel(r"$v_z$, m/s")
+    ax.set_xlabel("Time, sec")
+    ax.set_ylim(-5, 5)
+
+    """ Figure 2 - Rotor thrusts """
+    fig, axs = plt.subplots(3, 2, sharex=True)
+    ylabels = np.array(
+        (["Rotor 1", "Rotor 2"], ["Rotor 3", "Rotor 4"], ["Rotor 5", "Rotor 6"])
+    )
+    for i, _ylabel in np.ndenumerate(ylabels):
+        x, y = i
+        ax = axs[i]
+        ax.plot(data["t"], data["ctrls"].squeeze(-1)[:, 2 * x + y], "k-")
+        ax.set_xlim(data["t"][0], data["t"][-1])
+        if i[0] == 2:
+            ax.set_xlabel("Time, sec")
+
+        plt.setp(ax, ylabel=_ylabel)
+
+    fig.tight_layout()
+    fig.subplots_adjust(wspace=0.5)
+    fig.align_ylabels(axs)
+
+    """ Figure 3 - Pusher and Control surfaces """
+    fig, axs = plt.subplots(5, 1, sharex=True)
+    ylabels = np.array(
+        ("Pusher 1", "Pusher 2", r"$\delta_a$", r"$\delta_e$", r"$\delta_r$")
+    )
+    for i, _ylabel in enumerate(ylabels):
+        ax = axs[i]
+        ax.plot(data["t"], data["ctrls"].squeeze(-1)[:, i + 6], "k-")
+        ax.set_xlim(data["t"][0], data["t"][-1])
+        ax.grid()
+        plt.setp(ax, ylabel=_ylabel)
+
+        if i == 4:
+            ax.set_xlabel("Time, sec")
+
+    fig.tight_layout()
+    fig.align_ylabels(axs)
+
+    """ Figure 4 - Generalized forces """
+    fig, axs = plt.subplots(3, 2)
+    ylabels = np.array((["Fx", "Mx"], ["Fy", "My"], ["Fz", "Mz"]))
+    for i, _ylabel in np.ndenumerate(ylabels):
+        x, y = i
+        ax = axs[i]
+        ax.plot(data["t"], data["FM"].squeeze(-1)[:, 2 * x + y], "k-")
+        ax.set_xlim(data["t"][0], data["t"][-1])
+        if i[0] == 2:
+            ax.set_xlabel("Time, sec")
+
+    plt.gcf().supylabel("Generalized Forces")
+
+    fig.tight_layout()
+    fig.subplots_adjust(wspace=0.5)
+    fig.align_ylabels(axs)
+
+    plt.show()
+
+
+def main(args):
+    if args.only_plot:
+        plot()
+        return
+    else:
+        run()
+        if args.plot:
+            plot()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--plot", action="store_true")
+    parser.add_argument("-P", "--only-plot", action="store_true")
+    args = parser.parse_args()
+    main(args)

--- a/ftc/controllers/LQR/lqr_LC62.py
+++ b/ftc/controllers/LQR/lqr_LC62.py
@@ -6,12 +6,7 @@ from fym.utils.rot import quat2angle
 class LQRController(fym.BaseEnv):
     def __init__(self, env):
         super().__init__()
-        (
-            pos_trim,
-            vel_trim,
-            quat_trim,
-            omega_trim,
-        ) = env.plant.x_trims
+        (pos_trim, vel_trim, quat_trim, omega_trim) = env.x_trims_HV
         ang_trim = np.vstack(quat2angle(quat_trim)[::-1])
 
         rotor_trim = env.plant.u_trims_vtol
@@ -31,80 +26,12 @@ class LQRController(fym.BaseEnv):
         x = np.vstack((pos, vel, ang, omega))
 
         posd, veld = env.get_ref(t, "posd", "posd_dot")
-        angd = self.x_trims[6:9]
-        omegad = self.x_trims[9:]
-        x_ref = np.vstack((posd, veld, angd, omegad))
-
-        ctrls = -self.K.dot(x - x_ref) + self.u_trims
-
-        controller_info = {
-            "posd": posd,
-            "veld": veld,
-            "angd": angd,
-            "omegad": omegad,
-            "ang": ang,
-        }
-
-        return ctrls, controller_info
-
-
-class LQR_modeController(fym.BaseEnv):
-    def __init__(self, env):
-        super().__init__()
-
-        (
-            pos_trim,
-            vel_trim,
-            quat_trim,
-            omega_trim,
-        ) = env.x_trims_FW
-        ang_trim = np.vstack(quat2angle(quat_trim)[::-1])
-
-        rotor_trim = env.u_trims_vtol_FW
-        pusher_trim, dels_trim = env.u_trims_fixed_FW
-
-        self.x_trims_FW = np.vstack((pos_trim, vel_trim, ang_trim, omega_trim))
-        self.u_trims_FW = np.vstack((rotor_trim, pusher_trim, dels_trim))
-
-        (
-            pos_trim,
-            vel_trim,
-            quat_trim,
-            omega_trim,
-        ) = env.x_trims_HV
-        ang_trim = np.vstack(quat2angle(quat_trim)[::-1])
-
-        rotor_trim = env.u_trims_vtol_HV
-        pusher_trim, dels_trim = env.u_trims_fixed_HV
-
-        self.x_trims_HV = np.vstack((pos_trim, vel_trim, ang_trim, omega_trim))
-        self.u_trims_HV = np.vstack((rotor_trim, pusher_trim, dels_trim))
-
-        ptrb = 1e-9
-
-        A_FW, B_FW = env.plant.lin_model(self.x_trims_FW, self.u_trims_FW, ptrb)
-        A_HV, B_HV = env.plant.lin_model(self.x_trims_HV, self.u_trims_HV, ptrb)
-
-        self.K_HV, *_ = fym.agents.LQR.clqr(A_HV, B_HV[:, :6], env.Q_HV, env.R_HV)
-        self.K_FW, *_ = fym.agents.LQR.clqr(A_FW, B_FW[:, 6:], env.Q_FW, env.R_FW)
-
-    def get_control(self, t, env):
-        w_r = env.get_ref(t, "w_r")[0]
-        K = np.concatenate((w_r * self.K_HV, (1 - w_r) * self.K_FW), axis=0)
-
-        pos, vel, quat, omega = env.plant.observe_list()
-        ang = np.vstack(quat2angle(quat)[::-1])
-        x = np.vstack((pos, vel, ang, omega))
-
-        posd, veld = env.get_ref(t, "posd", "posd_dot")
         angd = np.zeros((3, 1))
         omegad = np.zeros((3, 1))
         x_ref = np.vstack((posd, veld, angd, omegad))
 
-        if w_r == 0:
-            ctrls = -K.dot(x - x_ref) + self.u_trims_FW
-        elif w_r == 1:
-            ctrls = -K.dot(x - x_ref) + self.u_trims_HV
+        ctrls0 = -self.K.dot(x - x_ref) + self.u_trims
+        ctrls = env.plant.saturate(ctrls0)
 
         controller_info = {
             "posd": posd,
@@ -120,170 +47,65 @@ class LQR_modeController(fym.BaseEnv):
 class LQR_FMController(fym.BaseEnv):
     def __init__(self, env):
         super().__init__()
-        (
-            pos_trim,
-            vel_trim,
-            quat_trim,
-            omega_trim,
-        ) = env.plant.x_trims
+        # VTOL mode
+        (pos_trim, vel_trim, quat_trim, omega_trim) = env.x_trims_HV
         ang_trim = np.vstack(quat2angle(quat_trim)[::-1])
 
-        rotor_trim = env.plant.u_trims_vtol
-        pusher_trim, dels_trim = env.plant.u_trims_fixed
+        rotor_trim = env.u_trims_vtol_HV
+        pusher_trim, dels_trim = env.u_trims_fixed_HV
 
-        self.x_trims = np.vstack((pos_trim, vel_trim, ang_trim, omega_trim))
-        self.u_trims = np.vstack((rotor_trim, pusher_trim, dels_trim))
-        self.FM_trim = env.plant.get_FM(
-            pos_trim, vel_trim, quat_trim, omega_trim, self.u_trims
+        self.x_trims_HV = np.vstack((pos_trim, vel_trim, ang_trim, omega_trim))
+        self.u_trims_HV = np.vstack((rotor_trim, pusher_trim, dels_trim))
+        self.FM_trims_HV = env.plant.get_FM(
+            pos_trim, vel_trim, quat_trim, omega_trim, self.u_trims_HV
         )
 
         ptrb = 1e-9
+        A_HV, B_HV = env.plant.lin_model_FM(self.x_trims_HV, self.FM_trims_HV, ptrb)
+        self.K_HV, *_ = fym.agents.LQR.clqr(A_HV, B_HV, env.Q_HV, env.R_HV)
 
-        A, B = env.plant.lin_model_FM(self.x_trims, self.FM_trim, ptrb)
-        self.K, *_ = fym.agents.LQR.clqr(A, B, env.Q, env.R)
-
-    def get_control(self, t, env):
-        pos, vel, quat, omega = env.plant.observe_list()
-        ang = np.vstack(quat2angle(quat)[::-1])
-
-        x = np.vstack((pos, vel, ang, omega))
-        x_ref = self.x_trims
-
-        FM_ctrl = -self.K.dot(x - x_ref) + self.FM_trim
-        controller_info = {
-            "posd": self.x_trims[0:3],
-            "veld": self.x_trims[3:6],
-            "angd": self.x_trims[6:9],
-        }
-
-        return FM_ctrl, controller_info
-
-
-class LQR_FMCAController(fym.BaseEnv):
-    def __init__(self, env):
-        super().__init__()
-        (
-            pos_trim,
-            vel_trim,
-            quat_trim,
-            omega_trim,
-        ) = env.plant.x_trims
+        # FW mode
+        (pos_trim, vel_trim, quat_trim, omega_trim) = env.x_trims_FW
         ang_trim = np.vstack(quat2angle(quat_trim)[::-1])
 
-        rotor_trim = env.plant.u_trims_vtol
-        pusher_trim, dels_trim = env.plant.u_trims_fixed
+        rotor_trim = env.u_trims_vtol_FW
+        pusher_trim, dels_trim = env.u_trims_fixed_FW
 
-        self.x_trims = np.vstack((pos_trim, vel_trim, ang_trim, omega_trim))
-        self.u_trims = np.vstack((rotor_trim, pusher_trim, dels_trim))
-        self.FM_trim = env.plant.get_FM(
-            pos_trim, vel_trim, quat_trim, omega_trim, self.u_trims
-        )
-        self.B_Gravity = env.plant.B_Gravity(quat_trim)
-
-        ptrb = 1e-9
-
-        A, B = env.plant.lin_model_FM(self.x_trims, self.FM_trim, ptrb)
-        self.K, *_ = fym.agents.LQR.clqr(A, B, env.Q, env.R)
-
-    def CA_Bmatrix(self, env):
-        # 6x6 B_VTOL matrix w.r.t. thrust of each rotors
-        dx1, dx2, dx3 = env.plant.dx1, env.plant.dx2, env.plant.dx3
-        dy1, dy2 = env.plant.dy1, env.plant.dy2
-        self.Cth_r = np.array(([178, -22]))  # th_r = 178*rcmds-22
-        Ctqth_r = 0.0338  # tq_r / th_r
-        self.B_r2FM = np.array(
-            (
-                [0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0],
-                [-1, -1, -1, -1, -1, -1],
-                [-dy2, dy1, dy1, -dy2, -dy2, dy1],
-                [-dx2, -dx2, dx1, -dx3, dx1, -dx3],
-                [-Ctqth_r, Ctqth_r, -Ctqth_r, Ctqth_r, Ctqth_r, -Ctqth_r],
-            )
+        self.x_trims_FW = np.vstack((pos_trim, vel_trim, ang_trim, omega_trim))
+        self.u_trims_FW = np.vstack((rotor_trim, pusher_trim, dels_trim))
+        self.FM_trims_FW = env.plant.get_FM(
+            pos_trim, vel_trim, quat_trim, omega_trim, self.u_trims_FW
         )
 
-        # 6x2 B_Pusher matrix w.r.t. thrust of each pushers
-        # self.Cth_p = 108.2 # th_p = 108.2*rcmds**2
-        self.Cth_p = np.array(([84, -12]))  # th_p = 84*rcmds-12
-        Ctqth_p = 0.0835  # tq_p / th_p
-        self.B_p2FM = np.array(
-            ([1, 1], [0, 0], [0, 0], [Ctqth_p, -Ctqth_p], [0, 0], [0, 0])
-        )
+        A_FW, B_FW = env.plant.lin_model_FM(self.x_trims_FW, self.FM_trims_FW, ptrb)
+        self.K_FW, *_ = fym.agents.LQR.clqr(A_FW, B_FW, env.Q_FW, env.R_FW)
 
-        # 6x3 B_Fuselage matrix w.r.t. dels
-        pos = self.x_trims[0:3]
-        vel = self.x_trims[3:6]
-        rho = env.plant.get_rho(-pos[2])
-        VT = np.linalg.norm(vel)
-        qbar = 0.5 * rho * VT**2
-        alp = np.arctan2(vel[2], vel[0])
-        CL, CD, CM = env.plant.aero_coeff(alp)
-        S, S2, St = env.plant.S, env.plant.S2, env.plant.St
-        b, c, d = env.plant.b, env.plant.c, env.plant.d
-
-        Cy_del_R, Cll_del_A, Cll_del_R = (
-            env.plant.Cy_del_R,
-            env.plant.Cll_del_A,
-            env.plant.Cll_del_R,
-        )
-        Cm_del_A, Cm_del_E, Cn_del_A, Cn_del_R = (
-            env.plant.Cm_del_A,
-            env.plant.Cm_del_E,
-            env.plant.Cn_del_A,
-            env.plant.Cn_del_R,
-        )
-
-        self.B_dels2FM = qbar * np.array(
-            (
-                [0, 0, 0],
-                [0, 0, S * Cy_del_R],
-                [0, 0, 0],
-                [S2 * b * Cll_del_A, 0, S * b * Cll_del_R],
-                [S * c * Cm_del_A, S * c * Cm_del_E, 0],
-                [St * d * Cn_del_A, 0, St * d * Cn_del_R],
-            )
-        )
-
-        self.B_ctrl2FM = np.hstack((self.B_r2FM, self.B_p2FM, self.B_dels2FM))
-        self.B_const = qbar * S * np.vstack((-CD, 0, -CL, 0, c * CM, 0))
-
-        return self.B_ctrl2FM, self.B_const
 
     def get_control(self, t, env):
-        # present state
+        mode = env.get_ref(t, "mode")[0]
+
         pos, vel, quat, omega = env.plant.observe_list()
         ang = np.vstack(quat2angle(quat)[::-1])
         x = np.vstack((pos, vel, ang, omega))
-
-        # reference state
-        # x_ref = self.x_trims
+        
         posd, veld = env.get_ref(t, "posd", "posd_dot")
-        angd = self.x_trims[6:9]
-        omegad = self.x_trims[9:]
+        angd = np.zeros((3, 1))
+        omegad = np.zeros((3, 1))
         x_ref = np.vstack((posd, veld, angd, omegad))
 
-        # get control
-        # ctrls = -self.K.dot(x - x_ref) + self.u_trims
+        # desired virtual input FM
+        if mode == "VTOL":
+            K = self.K_HV
+            x_trims = self.x_trims_HV
+            u_trims = self.u_trims_HV
+            FM_trims = self.FM_trims_HV
+        elif mode == "FW":
+            K = self.K_FW
+            x_trims = self.x_trims_FW
+            u_trims = self.u_trims_FW
+            FM_trims = self.FM_trims_FW
 
-        FM_ctrl = -self.K.dot(x - x_ref)
-        B_ctrl2FM, B_const = self.CA_Bmatrix(env)
-        B_FM2th = np.linalg.pinv(B_ctrl2FM)
-
-        th_ctrl = B_FM2th.dot(FM_ctrl)
-        th_r = th_ctrl[0:6]
-        th_p = th_ctrl[6:8]
-        dels = th_ctrl[8:11] + self.u_trims[8:]
-
-        self.cmd_trims = np.copy(self.u_trims)
-        self.cmd_trims[:8] = env.plant.pwm2cmd(self.cmd_trims[:8])
-
-        rcmds_r = (th_r / self.Cth_r[0]) + self.cmd_trims[:6]
-        rcmds_p = (th_p / self.Cth_p[0]) + self.cmd_trims[6:8]
-
-        pwms_rotor = env.plant.cmd2pwm(rcmds_r)
-        pwms_pusher = env.plant.cmd2pwm(rcmds_p)
-
-        ctrls = np.vstack((pwms_rotor, pwms_pusher, dels))
+        FM_ctrl = -K.dot(x - x_ref) + FM_trims
         controller_info = {
             "posd": posd,
             "veld": veld,
@@ -292,4 +114,4 @@ class LQR_FMCAController(fym.BaseEnv):
             "ang": ang,
         }
 
-        return ctrls, controller_info
+        return FM_ctrl, controller_info

--- a/ftc/controllers/LQR/lqr_LC62_CA.py
+++ b/ftc/controllers/LQR/lqr_LC62_CA.py
@@ -1,17 +1,39 @@
 import fym
 import numpy as np
+import cvxpy as cp
 from fym.utils.rot import quat2angle
 
-class LQR_PIController(fym.BaseEnv):
+def constrained_lasso(b, nu_d):
+    _, dim_u = b.shape
+    u = cp.Variable((dim_u,1))
+    objective = cp.Minimize(cp.norm(u, 1))
+    constraints = [
+        nu_d == b @ u,
+    ]
+    prob = cp.Problem(objective, constraints)
+    _ = prob.solve()
+    return (u.value, prob.status)
+
+
+def penalty_lasso(b, nu_d, penalty_weight=1e3):
+    _, dim_u = b.shape
+    u = cp.Variable((dim_u,1))
+    objective = cp.Minimize(
+        cp.sum_squares(nu_d - b @ u)
+        + penalty_weight*cp.norm(u, 1)
+    )
+    constraints = []
+    prob = cp.Problem(objective, constraints)
+    _ = prob.solve(solver=cp.ECOS)
+    return u.value
+
+
+
+class LQR_binaryController(fym.BaseEnv):
     def __init__(self, env):
         super().__init__()
-
-        (
-            pos_trim,
-            vel_trim,
-            quat_trim,
-            omega_trim,
-        ) = env.x_trims_HV
+        # VTOL mode
+        (pos_trim, vel_trim, quat_trim, omega_trim) = env.x_trims_HV
         ang_trim = np.vstack(quat2angle(quat_trim)[::-1])
 
         rotor_trim = env.u_trims_vtol_HV
@@ -19,15 +41,13 @@ class LQR_PIController(fym.BaseEnv):
 
         self.x_trims_HV = np.vstack((pos_trim, vel_trim, ang_trim, omega_trim))
         self.u_trims_HV = np.vstack((rotor_trim, pusher_trim, dels_trim))
-        self.FM_trims_HV = env.plant.get_FM(pos_trim, vel_trim, quat_trim, omega_trim, self.u_trims_HV)
 
+        ptrb = 1e-9
+        A_HV, B_HV = env.plant.lin_model(self.x_trims_HV, self.u_trims_HV, ptrb)
+        self.K_HV, *_ = fym.agents.LQR.clqr(A_HV, B_HV[:, :6], env.Q_HV, env.R_HV)
 
-        (
-            pos_trim,
-            vel_trim,
-            quat_trim,
-            omega_trim,
-        ) = env.x_trims_FW
+        # FW mode
+        (pos_trim, vel_trim, quat_trim, omega_trim) = env.x_trims_FW
         ang_trim = np.vstack(quat2angle(quat_trim)[::-1])
 
         rotor_trim = env.u_trims_vtol_FW
@@ -35,18 +55,12 @@ class LQR_PIController(fym.BaseEnv):
 
         self.x_trims_FW = np.vstack((pos_trim, vel_trim, ang_trim, omega_trim))
         self.u_trims_FW = np.vstack((rotor_trim, pusher_trim, dels_trim))
-        self.FM_trims_FW = env.plant.get_FM(pos_trim, vel_trim, quat_trim, omega_trim, self.u_trims_FW)
 
-        ptrb = 1e-9
-
-        A_HV, B_HV = env.plant.lin_model_FM(self.x_trims_HV, self.FM_trims_HV, ptrb)
-        A_FW, B_FW = env.plant.lin_model_FM(self.x_trims_FW, self.FM_trims_FW, ptrb)
-
-        self.K_HV, *_ = fym.agents.LQR.clqr(A_HV, B_HV, env.Q_HV, env.R_HV)
-        self.K_FW, *_ = fym.agents.LQR.clqr(A_FW, B_FW, env.Q_FW, env.R_FW)
+        A_FW, B_FW = env.plant.lin_model(self.x_trims_FW, self.u_trims_FW, ptrb)
+        self.K_FW, *_ = fym.agents.LQR.clqr(A_FW, B_FW[:, 6:], env.Q_FW, env.R_FW)
 
     def get_control(self, t, env):
-        # mode from high level controller - char type 
+        # mode from high level controller - char type
         mode = env.get_ref(t, "mode")[0]
         pos, vel, quat, omega = env.plant.observe_list()
         ang = np.vstack(quat2angle(quat)[::-1])
@@ -57,43 +71,104 @@ class LQR_PIController(fym.BaseEnv):
         omegad = np.zeros((3, 1))
         x_ref = np.vstack((posd, veld, angd, omegad))
 
-        # desired virtual input FM
         if mode == "VTOL":
-            FM_ctrls = -self.K_HV.dot(x - x_ref) + self.FM_trims_HV
+            w_r = 1
+            x_trims = self.x_trims_HV
+            u_trims = self.u_trims_HV
         elif mode == "FW":
-            FM_ctrls = -self.K_FW.dot(x - x_ref) + self.FM_trims_FW
+            w_r = 0
+            x_trims = self.x_trims_FW
+            u_trims = self.u_trims_FW
 
+        K = np.concatenate((w_r * self.K_HV, (1 - w_r) * self.K_FW), axis=0)
+
+        ctrls0 = -K.dot(x - x_ref) + u_trims
+        ctrls = env.plant.saturate(ctrls0)
+        controller_info = {
+            "posd": posd,
+            "veld": veld,
+            "angd": angd,
+            "omegad": omegad,
+            "ang": ang,
+        }
+
+        return ctrls, controller_info
+
+
+class LQR_PIController(fym.BaseEnv):
+    def __init__(self, env):
+        super().__init__()
+        # VTOL mode
+        (pos_trim, vel_trim, quat_trim, omega_trim) = env.x_trims_HV
+        ang_trim = np.vstack(quat2angle(quat_trim)[::-1])
+
+        rotor_trim = env.u_trims_vtol_HV
+        pusher_trim, dels_trim = env.u_trims_fixed_HV
+
+        self.x_trims_HV = np.vstack((pos_trim, vel_trim, ang_trim, omega_trim))
+        self.u_trims_HV = np.vstack((rotor_trim, pusher_trim, dels_trim))
+        self.FM_trims_HV = env.plant.get_FM(
+            pos_trim, vel_trim, quat_trim, omega_trim, self.u_trims_HV
+        )
+
+        ptrb = 1e-9
+        A_HV, B_HV = env.plant.lin_model_FM(self.x_trims_HV, self.FM_trims_HV, ptrb)
+        self.K_HV, *_ = fym.agents.LQR.clqr(A_HV, B_HV, env.Q_HV, env.R_HV)
+
+        # FW mode
+        (pos_trim, vel_trim, quat_trim, omega_trim) = env.x_trims_FW
+        ang_trim = np.vstack(quat2angle(quat_trim)[::-1])
+
+        rotor_trim = env.u_trims_vtol_FW
+        pusher_trim, dels_trim = env.u_trims_fixed_FW
+
+        self.x_trims_FW = np.vstack((pos_trim, vel_trim, ang_trim, omega_trim))
+        self.u_trims_FW = np.vstack((rotor_trim, pusher_trim, dels_trim))
+        self.FM_trims_FW = env.plant.get_FM(
+            pos_trim, vel_trim, quat_trim, omega_trim, self.u_trims_FW
+        )
+
+        A_FW, B_FW = env.plant.lin_model_FM(self.x_trims_FW, self.FM_trims_FW, ptrb)
+        self.K_FW, *_ = fym.agents.LQR.clqr(A_FW, B_FW, env.Q_FW, env.R_FW)
+
+    def control_effectiveness(self, t, env):
         # control effectiveness matrix B
         dx1, dx2, dx3 = env.plant.dx1, env.plant.dx2, env.plant.dx3
         dy1, dy2 = env.plant.dy1, env.plant.dy2
-        r = 0.0338 # tq_r / th_r
-        self.B_r2FM = np.array((
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            [-1, -1, -1, -1, -1, -1],
-            [-dy2, dy1, dy1, -dy2, -dy2, dy1],
-            [-dx2, -dx2, dx1, -dx3, dx1, -dx3],
-            [-r, r, -r, r, r, -r],
-        ))
+        r1 = 130  # r1 = th_r / rcmds
+        r2 = 0.0338  # r2 = tq_r / th_r
+        B_r2FM = r1 * np.array(
+            (
+                [0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0],
+                [-1, -1, -1, -1, -1, -1],
+                [-dy2, dy1, dy1, -dy2, -dy2, dy1],
+                [-dx2, -dx2, dx1, -dx3, dx1, -dx3],
+                [-r2, r2, -r2, r2, r2, -r2],
+            )
+        )
 
-        p = 0.0835 # tq_p / th_p
-        self.B_p2FM = np.array((
-            [1, 1],
-            [0, 0],
-            [0, 0],
-            [p, -p],
-            [0, 0],
-            [0, 0],
-        ))
-        
+        p1 = 70  # p1 = th_p / pcmds
+        p2 = 0.0835  # p2 = tq_p / th_p
+        B_p2FM = p1 * np.array(
+            (
+                [1, 1],
+                [0, 0],
+                [0, 0],
+                [p2, -p2],
+                [0, 0],
+                [0, 0],
+            )
+        )
 
+        mode = env.get_ref(t, "mode")[0]
         if mode == "VTOL":
-            pos = self.x_trims_HV[0:3]
-            vel = self.x_trims_HV[3:6]
+            x_trims = self.x_trims_HV
         elif mode == "FW":
-            pos = self.x_trims_FW[0:3]
-            vel = self.x_trims_FW[3:6]
+            x_trims = self.x_trims_FW
 
+        pos = x_trims[0:3]
+        vel = x_trims[3:6]
         rho = env.plant.get_rho(-pos[2])
         VT = np.linalg.norm(vel)
         qbar = 0.5 * rho * VT**2
@@ -114,7 +189,7 @@ class LQR_PIController(fym.BaseEnv):
             env.plant.Cn_del_R,
         )
 
-        self.B_dels2FM = qbar * np.array(
+        B_dels2FM = qbar * np.array(
             (
                 [0, 0, 0],
                 [0, 0, S * Cy_del_R],
@@ -125,11 +200,41 @@ class LQR_PIController(fym.BaseEnv):
             )
         )
 
-        B_u2FM = np.hstack((self.B_r2FM, self.B_p2FM, self.B_dels2FM))
-        B_const = qbar * S * np.vstack((-CD, 0, -CL, 0, c*CM, 0))
+        B = np.hstack((B_r2FM, B_p2FM, B_dels2FM))
+        return B
 
-        # Control Allocation
-        ctrls = np.linalg.pinv(B_u2FM).dot(FM_ctrls - B_const)
+    def get_control(self, t, env):
+        # mode from high level controller - char type
+        mode = env.get_ref(t, "mode")[0]
+
+        pos, vel, quat, omega = env.plant.observe_list()
+        ang = np.vstack(quat2angle(quat)[::-1])
+        x = np.vstack((pos, vel, ang, omega))
+
+        posd, veld = env.get_ref(t, "posd", "posd_dot")
+        angd = np.zeros((3, 1))
+        omegad = np.zeros((3, 1))
+        x_ref = np.vstack((posd, veld, angd, omegad))
+
+        # desired virtual input FM
+        if mode == "VTOL":
+            K = self.K_HV
+            x_trims = self.x_trims_HV
+            u_trims = self.u_trims_HV
+            FM_trims = self.FM_trims_HV
+        elif mode == "FW":
+            K = self.K_FW
+            x_trims = self.x_trims_FW
+            u_trims = self.u_trims_FW
+            FM_trims = self.FM_trims_FW
+
+        FM_ctrls = -K.dot(x - x_ref)
+
+        # control effectiveness matrix
+        B_u2FM = self.control_effectiveness(t, env)
+
+        ctrls0 = np.linalg.pinv(B_u2FM).dot(FM_ctrls) + u_trims
+        ctrls = env.plant.saturate(ctrls0)
         controller_info = {
             "posd": posd,
             "veld": veld,
@@ -141,8 +246,161 @@ class LQR_PIController(fym.BaseEnv):
         return ctrls, controller_info
 
 
+class LQR_L1normController(fym.BaseEnv):
+    def __init__(self, env):
+        super().__init__()
+        # VTOL mode
+        (pos_trim, vel_trim, quat_trim, omega_trim) = env.x_trims_HV
+        ang_trim = np.vstack(quat2angle(quat_trim)[::-1])
 
+        rotor_trim = env.u_trims_vtol_HV
+        pusher_trim, dels_trim = env.u_trims_fixed_HV
 
+        self.x_trims_HV = np.vstack((pos_trim, vel_trim, ang_trim, omega_trim))
+        self.u_trims_HV = np.vstack((rotor_trim, pusher_trim, dels_trim))
+        self.FM_trims_HV = env.plant.get_FM(
+            pos_trim, vel_trim, quat_trim, omega_trim, self.u_trims_HV
+        )
 
+        ptrb = 1e-9
+        A_HV, B_HV = env.plant.lin_model_FM(self.x_trims_HV, self.FM_trims_HV, ptrb)
+        self.K_HV, *_ = fym.agents.LQR.clqr(A_HV, B_HV, env.Q_HV, env.R_HV)
+
+        # FW mode
+        (pos_trim, vel_trim, quat_trim, omega_trim) = env.x_trims_FW
+        ang_trim = np.vstack(quat2angle(quat_trim)[::-1])
+
+        rotor_trim = env.u_trims_vtol_FW
+        pusher_trim, dels_trim = env.u_trims_fixed_FW
+
+        self.x_trims_FW = np.vstack((pos_trim, vel_trim, ang_trim, omega_trim))
+        self.u_trims_FW = np.vstack((rotor_trim, pusher_trim, dels_trim))
+        self.FM_trims_FW = env.plant.get_FM(
+            pos_trim, vel_trim, quat_trim, omega_trim, self.u_trims_FW
+        )
+
+        A_FW, B_FW = env.plant.lin_model_FM(self.x_trims_FW, self.FM_trims_FW, ptrb)
+        self.K_FW, *_ = fym.agents.LQR.clqr(A_FW, B_FW, env.Q_FW, env.R_FW)
+            
 
     
+    def control_effectiveness(self, t, env):
+        # control effectiveness matrix B
+        dx1, dx2, dx3 = env.plant.dx1, env.plant.dx2, env.plant.dx3
+        dy1, dy2 = env.plant.dy1, env.plant.dy2
+        r1 = 130  # r1 = th_r / rcmds
+        r2 = 0.0338  # r2 = tq_r / th_r
+        B_r2FM = r1 * np.array(
+            (
+                [0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0],
+                [-1, -1, -1, -1, -1, -1],
+                [-dy2, dy1, dy1, -dy2, -dy2, dy1],
+                [-dx2, -dx2, dx1, -dx3, dx1, -dx3],
+                [-r2, r2, -r2, r2, r2, -r2],
+            )
+        )
+
+        p1 = 70  # p1 = th_p / pcmds
+        p2 = 0.0835  # p2 = tq_p / th_p
+        B_p2FM = p1 * np.array(
+            (
+                [1, 1],
+                [0, 0],
+                [0, 0],
+                [p2, -p2],
+                [0, 0],
+                [0, 0],
+            )
+        )
+
+        # mode = env.get_ref(t, "mode")[0]
+        # if mode == "VTOL":
+        #     x_trims = self.x_trims_HV
+        # elif mode == "FW":
+        #     x_trims = self.x_trims_FW
+
+        pos, vel, quat, omega = env.plant.observe_list()
+        rho = env.plant.get_rho(-pos[2])
+        VT = np.linalg.norm(vel)
+        qbar = 0.5 * rho * VT**2
+        alp = np.arctan2(vel[2], vel[0])
+        CL, CD, CM = env.plant.aero_coeff(alp)
+        S, S2, St = env.plant.S, env.plant.S2, env.plant.St
+        b, c, d = env.plant.b, env.plant.c, env.plant.d
+
+        Cy_del_R, Cll_del_A, Cll_del_R = (
+            env.plant.Cy_del_R,
+            env.plant.Cll_del_A,
+            env.plant.Cll_del_R,
+        )
+        Cm_del_A, Cm_del_E, Cn_del_A, Cn_del_R = (
+            env.plant.Cm_del_A,
+            env.plant.Cm_del_E,
+            env.plant.Cn_del_A,
+            env.plant.Cn_del_R,
+        )
+
+        B_dels2FM = qbar * np.array(
+            (
+                [0, 0, 0],
+                [0, 0, S * Cy_del_R],
+                [0, 0, 0],
+                [S2 * b * Cll_del_A, 0, S * b * Cll_del_R],
+                [S * c * Cm_del_A, S * c * Cm_del_E, 0],
+                [St * d * Cn_del_A, 0, St * d * Cn_del_R],
+            )
+        )
+
+        B = np.hstack((B_r2FM, B_p2FM, B_dels2FM))
+        return B
+
+    def allocation(self, B, nu_d):
+        """
+        L1 norm optimization-based control allocation
+
+        Input:
+            small pertubation of virtual input nu_d (6x1)
+            control effectiveness B (6x11)
+        Output:
+            small pertubation of control input commands (11x1)
+        """
+        # u = self.constrained_lasso(B, nu_d)
+        u = penalty_lasso(B, nu_d)
+        return u
+
+    def get_control(self, t, env):
+        pos, vel, quat, omega = env.plant.observe_list()
+        ang = np.vstack(quat2angle(quat)[::-1])
+        x = np.vstack((pos, vel, ang, omega))
+
+        posd, veld = env.get_ref(t, "posd", "posd_dot")
+        angd = np.zeros((3, 1))
+        omegad = np.zeros((3, 1))
+        x_ref = np.vstack((posd, veld, angd, omegad))
+
+        mode = env.get_ref(t, "mode")[0]
+        if mode == "VTOL":
+            K = self.K_HV
+            x_trims = self.x_trims_HV
+            u_trims = self.u_trims_HV
+        elif mode == "FW":
+            K = self.K_FW
+            x_trims = self.x_trims_FW
+            u_trims = self.u_trims_FW
+
+        nu_d = -K.dot(x - x_ref)
+        B = self.control_effectiveness(t, env)
+        del_u = self.allocation(B, nu_d)
+        ctrls0 = u_trims + del_u
+        ctrls = env.plant.saturate(ctrls0)
+        controller_info = {
+            "posd": posd,
+            "veld": veld,
+            "angd": angd,
+            "omegad": omegad,
+            "ang": ang,
+            # "ctrls0": ctrls0,
+        }
+
+        return ctrls, controller_info

--- a/ftc/controllers/LQR/lqr_LC62_CA.py
+++ b/ftc/controllers/LQR/lqr_LC62_CA.py
@@ -1,0 +1,148 @@
+import fym
+import numpy as np
+from fym.utils.rot import quat2angle
+
+class LQR_PIController(fym.BaseEnv):
+    def __init__(self, env):
+        super().__init__()
+
+        (
+            pos_trim,
+            vel_trim,
+            quat_trim,
+            omega_trim,
+        ) = env.x_trims_HV
+        ang_trim = np.vstack(quat2angle(quat_trim)[::-1])
+
+        rotor_trim = env.u_trims_vtol_HV
+        pusher_trim, dels_trim = env.u_trims_fixed_HV
+
+        self.x_trims_HV = np.vstack((pos_trim, vel_trim, ang_trim, omega_trim))
+        self.u_trims_HV = np.vstack((rotor_trim, pusher_trim, dels_trim))
+        self.FM_trims_HV = env.plant.get_FM(pos_trim, vel_trim, quat_trim, omega_trim, self.u_trims_HV)
+
+
+        (
+            pos_trim,
+            vel_trim,
+            quat_trim,
+            omega_trim,
+        ) = env.x_trims_FW
+        ang_trim = np.vstack(quat2angle(quat_trim)[::-1])
+
+        rotor_trim = env.u_trims_vtol_FW
+        pusher_trim, dels_trim = env.u_trims_fixed_FW
+
+        self.x_trims_FW = np.vstack((pos_trim, vel_trim, ang_trim, omega_trim))
+        self.u_trims_FW = np.vstack((rotor_trim, pusher_trim, dels_trim))
+        self.FM_trims_FW = env.plant.get_FM(pos_trim, vel_trim, quat_trim, omega_trim, self.u_trims_FW)
+
+        ptrb = 1e-9
+
+        A_HV, B_HV = env.plant.lin_model_FM(self.x_trims_HV, self.FM_trims_HV, ptrb)
+        A_FW, B_FW = env.plant.lin_model_FM(self.x_trims_FW, self.FM_trims_FW, ptrb)
+
+        self.K_HV, *_ = fym.agents.LQR.clqr(A_HV, B_HV, env.Q_HV, env.R_HV)
+        self.K_FW, *_ = fym.agents.LQR.clqr(A_FW, B_FW, env.Q_FW, env.R_FW)
+
+    def get_control(self, t, env):
+        # mode from high level controller - char type 
+        mode = env.get_ref(t, "mode")[0]
+        pos, vel, quat, omega = env.plant.observe_list()
+        ang = np.vstack(quat2angle(quat)[::-1])
+        x = np.vstack((pos, vel, ang, omega))
+
+        posd, veld = env.get_ref(t, "posd", "posd_dot")
+        angd = np.zeros((3, 1))
+        omegad = np.zeros((3, 1))
+        x_ref = np.vstack((posd, veld, angd, omegad))
+
+        # desired virtual input FM
+        if mode == "VTOL":
+            FM_ctrls = -self.K_HV.dot(x - x_ref) + self.FM_trims_HV
+        elif mode == "FW":
+            FM_ctrls = -self.K_FW.dot(x - x_ref) + self.FM_trims_FW
+
+        # control effectiveness matrix B
+        dx1, dx2, dx3 = env.plant.dx1, env.plant.dx2, env.plant.dx3
+        dy1, dy2 = env.plant.dy1, env.plant.dy2
+        r = 0.0338 # tq_r / th_r
+        self.B_r2FM = np.array((
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [-1, -1, -1, -1, -1, -1],
+            [-dy2, dy1, dy1, -dy2, -dy2, dy1],
+            [-dx2, -dx2, dx1, -dx3, dx1, -dx3],
+            [-r, r, -r, r, r, -r],
+        ))
+
+        p = 0.0835 # tq_p / th_p
+        self.B_p2FM = np.array((
+            [1, 1],
+            [0, 0],
+            [0, 0],
+            [p, -p],
+            [0, 0],
+            [0, 0],
+        ))
+        
+
+        if mode == "VTOL":
+            pos = self.x_trims_HV[0:3]
+            vel = self.x_trims_HV[3:6]
+        elif mode == "FW":
+            pos = self.x_trims_FW[0:3]
+            vel = self.x_trims_FW[3:6]
+
+        rho = env.plant.get_rho(-pos[2])
+        VT = np.linalg.norm(vel)
+        qbar = 0.5 * rho * VT**2
+        alp = np.arctan2(vel[2], vel[0])
+        CL, CD, CM = env.plant.aero_coeff(alp)
+        S, S2, St = env.plant.S, env.plant.S2, env.plant.St
+        b, c, d = env.plant.b, env.plant.c, env.plant.d
+
+        Cy_del_R, Cll_del_A, Cll_del_R = (
+            env.plant.Cy_del_R,
+            env.plant.Cll_del_A,
+            env.plant.Cll_del_R,
+        )
+        Cm_del_A, Cm_del_E, Cn_del_A, Cn_del_R = (
+            env.plant.Cm_del_A,
+            env.plant.Cm_del_E,
+            env.plant.Cn_del_A,
+            env.plant.Cn_del_R,
+        )
+
+        self.B_dels2FM = qbar * np.array(
+            (
+                [0, 0, 0],
+                [0, 0, S * Cy_del_R],
+                [0, 0, 0],
+                [S2 * b * Cll_del_A, 0, S * b * Cll_del_R],
+                [S * c * Cm_del_A, S * c * Cm_del_E, 0],
+                [St * d * Cn_del_A, 0, St * d * Cn_del_R],
+            )
+        )
+
+        B_u2FM = np.hstack((self.B_r2FM, self.B_p2FM, self.B_dels2FM))
+        B_const = qbar * S * np.vstack((-CD, 0, -CL, 0, c*CM, 0))
+
+        # Control Allocation
+        ctrls = np.linalg.pinv(B_u2FM).dot(FM_ctrls - B_const)
+        controller_info = {
+            "posd": posd,
+            "veld": veld,
+            "angd": angd,
+            "omegad": omegad,
+            "ang": ang,
+        }
+
+        return ctrls, controller_info
+
+
+
+
+
+
+    

--- a/ftc/controllers/__init__.py
+++ b/ftc/controllers/__init__.py
@@ -17,6 +17,10 @@ register(
     entry_point="ftc.controllers.LQR.lqr_LC62:LQR_modeController",
 )
 register(
+    id="LQR-LC62-PI",
+    entry_point="ftc.controllers.LQR.lqr_LC62_CA:LQR_PIController",
+)
+register(
     id="BLF",
     entry_point="ftc.controllers.BLF.BLF_g:BLFController",
 )

--- a/ftc/controllers/__init__.py
+++ b/ftc/controllers/__init__.py
@@ -13,12 +13,20 @@ register(
     entry_point="ftc.controllers.LQR.lqr_LC62:LQRController",
 )
 register(
-    id="LQR-LC62-mode",
-    entry_point="ftc.controllers.LQR.lqr_LC62:LQR_modeController",
+    id="LQR-LC62-binary",
+    entry_point="ftc.controllers.LQR.lqr_LC62_CA:LQR_binaryController",
+)
+register(
+    id="LQR-LC62-FM",
+    entry_point="ftc.controllers.LQR.lqr_LC62:LQR_FMController",
 )
 register(
     id="LQR-LC62-PI",
     entry_point="ftc.controllers.LQR.lqr_LC62_CA:LQR_PIController",
+)
+register(
+    id="LQR-LC62-L1norm",
+    entry_point="ftc.controllers.LQR.lqr_LC62_CA:LQR_L1normController",
 )
 register(
     id="BLF",

--- a/ftc/models/LC62R.py
+++ b/ftc/models/LC62R.py
@@ -506,12 +506,12 @@ class LC62R(fym.BaseEnv):
         vel = states[3:6]
         ang = states[6:9]
         omega = states[9:12]
-        quat = np.vstack(angle2quat(ang[2], ang[1], ang[0]))
+        quat = angle2quat(ang[2], ang[1], ang[0])
 
         FM = self.get_FM(pos, vel, quat, omega, ctrls)
         dots = self.deriv_ang(pos, vel, quat, ang, omega, FM)
         return np.vstack((dots))
-    
+
     def statefunc_FM(self, states, FM):
         pos = states[0:3]
         vel = states[3:6]
@@ -522,15 +522,13 @@ class LC62R(fym.BaseEnv):
         dots = self.deriv_ang(pos, vel, quat, ang, omega, FM)
         return np.vstack((dots))
 
-
     def lin_model(self, x, u, ptrb):
         self.A, self.B = linearization(self.statefunc, x, u, ptrb)
         return self.A, self.B
-    
+
     def lin_model_FM(self, x, FM, ptrb):
         self.A_FM, self.B_FM = linearization(self.statefunc_FM, x, FM, ptrb)
         return self.A_FM, self.B_FM
-
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(
     packages=find_packages(),
     python_requires=">=3.8",
     install_requires=[
-        "matplotlib"
+        "fym",
+        "scikit-learn",
+        "cvxpy",
+        "matplotlib",
     ]
 )


### PR DESCRIPTION
# Summary
L1-norm optimization-based control allocation methods are added.

## Features
- `constrained_lasso` (default): w/ constraint `nu_d = Bu`
- `penalty_lasso`: w/o constraint `nu_d = Bu` (augmented to the cost function)

# Notes
## To-do list (plz do the following or lmk what to do @yilinya0809)
- [ ] More realistic `nu_d` in the test code in `ftc/controllers/LQR/lqr_LC62_CA.py` (it is currently a zero vector).
- [ ] Add control input constraints (probably `control_limits` in `LC62R`?) considering plant specification.

## Tests
At the root,
```
python ftc/controllers/LQR/lqr_LC62_CA.py
```

Result:
```
(ftc-jiwon) ➜  fault-tolerant-control-jiwon git:(feature/LC62-CA-Transition-lasso) ✗ python ftc/controllers/LQR/lqr_LC62_CA.py
method: constrained_lasso
control input: [0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00
 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00
 1.23952081e-24 1.23952081e-24 1.23952081e-24]
method: penalty_lasso
control input: [-7.70426654e-33 -7.70426654e-33 -7.70426654e-33  1.16625547e-35
 -7.70426654e-33  1.16625547e-35 -1.91409429e-36 -1.91409429e-36
  1.08730301e-35  1.08730301e-35  1.08730301e-35]
```
## Bug fix (optional)
`setup.py` updated for deps management.

## Suggestion
I personally prefer to separate allocators from controllers to make them "encapsulated" for reusability :>
It was difficult to do so due to the method `control_effectiveness` defined in each LQR controller.
It should be defined in a lower-level class such as in a plant environment.
This makes it hard to make a module test for e.g. added allocator (circular import issue); resulting embarrassing test codes in the controller...


I just followed your construction of the classes for this time.